### PR TITLE
Filter duplicate triples

### DIFF
--- a/sparql-queries.ts
+++ b/sparql-queries.ts
@@ -12,7 +12,9 @@ const stream = namedNode(LDES_STREAM);
 const SPARQL_ENDPOINT_HEADERS = extractEndpointHeadersFromEnv(SPARQL_ENDPOINT_HEADER_PREFIX);
 
 function constructTriplesString(quads: RDF.Quad[]) {
-  let triplesString = quads.map(toString).join("\n");
+  let triplesString = quads.map(toString)
+      .filter((item, index, array) => array.indexOf(item) === index)
+      .join("\n");
   return triplesString;
 }
 


### PR DESCRIPTION
Avoid duplicates and reduce the size of inserted triples. Example:

```
query=
    INSERT DATA {
        GRAPH <http://stad.gent/ldes/dmg> {
            <https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://purl.org/dc/terms/isVersionOf> <https://stad.gent/id/mensgemaaktobject/dmg/530002589>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.w3.org/ns/prov#generatedAtTime> """2022-06-02T00:01:07.982Z"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://xmlns.com/foaf/0.1/page> <https://stad.gent/data/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.w3.org/ns/adms#identifier> <https://stad.gent/id/blank_node/426687f0-48ed-41df-8ba0-fbec19a3d7e1>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.w3.org/ns/adms#identifier> <https://stad.gent/id/blank_node/42e8c5df-bc4c-44b5-b218-4b13fdc487d2>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P50_has_current_keeper> <http://www.wikidata.org/entity/Q1809071>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> <https://stad.gent/id/concept/530010539>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> <https://stad.gent/id/concept/530010739>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> <https://stad.gent/id/mensgemaaktobject/dmg/530001285>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P41i_was_classified_by> <https://stad.gent/id/blank_node/a3b1ebcb-e390-40ea-a124-af0893ff4a6f>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P102_has_title> """Schoteltje van het servies 'Expression' uit de installatie 'Met dertien aan tafel'"""@nl.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P3_has_note> """In 1997-1998 maakte Pieter Stockmans de installatie ‘Met dertien aan tafel’ voor het Museum voor Sierkunst. De installatie is een servies voor dertien mensen. Het bestaat uit 755 stukken in porselein en kristalglas en combineert industrieel vervaardigd serviesgoed en ambachtelijke producten in een artistiek werk. Het dertiende exemplaar van een serviesonderdeel onderscheidt zich in kleur, decoratie of vorm. Het servies ‘Modus Vivendi’ uit 1992 vormde het uitgangspunt voor de installatie. Daarnaast gebruikte Stockmans onder meer onderdelen van het servies ‘Expression’ en tafelgerei ontworpen voor de Duitse juwelenfabrikant Niessing. Sommige porseleinen onderdelen werden uitgevoerd in het eigen atelier van Pieter Stockmans in Genk, andere in de Duitse porseleinfabriek Weimar Porzellan. Royal Leerdam Crystal vervaardigde de glazen objecten. Kort na de aankoop stelde het museum ‘Met dertien aan tafel’ tentoon in ‘Op mens en maat. Tweede Triënnale voor Vormgeving in Vlaanderen’ (1998-1999). Een selectie uit de 755 objecten stond opgesteld op een grote, glazen tafel. Het serviesgoed van Pieter Stockmans werd er gecombineerd met het bestek 733 van Carl Pott."""@nl.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by> <https://stad.gent/id/blank_node/69dbaaba-464d-44d7-bf07-c3b7c77aa155>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P108i_was_produced_by> <https://stad.gent/id/blank_node/bc3ff85a-2e26-49c8-acfe-5ef0e30189d6>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P108i_was_produced_by> <https://stad.gent/id/blank_node/abab9b7a-61f9-4af8-972d-9fa07703dfbe>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P108i_was_produced_by> <https://stad.gent/id/blank_node/8ee08357-e62c-4ca4-95d7-98fb22babd78>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P45_consists_of> <https://stad.gent/id/blank_node/d9e99960-198b-4d95-8cc2-3fa50afc279f>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P43_has_dimension> <https://stad.gent/id/blank_node/5e640a43-891e-4c83-a9a8-250933ee7d30>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P43_has_dimension> <https://stad.gent/id/blank_node/3d13b16d-00e2-4d09-8bdd-a44a7fade41d>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P24i_changed_ownership_through> <https://stad.gent/id/blank_node/80d2f5a1-cd5f-49d0-b20a-44417ab54773>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P55_has_current_location> <https://stad.gent/id/blank_node/ec8c50f5-e1a8-49c2-950d-4e859f9022b5>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.cidoc-crm.org/cidoc-crm/P129i_is_subject_of> <https://api.collectie.gent/iiif/presentation/v2/manifest/dmg:1998-0024_593-755>.
<https://stad.gent/id/mensgemaaktobject/dmg/530002589/2022-06-02T00:01:07.982Z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E22_Man-Made_Object>.
<https://api.collectie.gent/iiif/presentation/v2/manifest/dmg:1998-0024_593-755> <http://purl.org/dc/terms/conformsTo> <https://iiif.io/api/presentation>.
<https://api.collectie.gent/iiif/presentation/v2/manifest/dmg:1998-0024_593-755> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.ics.forth.gr/isl/CRMdig/D1_Digital_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://iiif.io/api/presentation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>.
<https://stad.gent/id/blank_node/ec8c50f5-e1a8-49c2-950d-4e859f9022b5> <http://www.w3.org/2004/02/skos/core#note> """depot"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://stad.gent/id/blank_node/80d2f5a1-cd5f-49d0-b20a-44417ab54773> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E8_Acquisition>.
<https://stad.gent/id/blank_node/80d2f5a1-cd5f-49d0-b20a-44417ab54773> <http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span> <https://stad.gent/id/blank_node/d8580ed6-9cbc-4489-972b-1f13821cbbbf>.
<https://stad.gent/id/blank_node/80d2f5a1-cd5f-49d0-b20a-44417ab54773> <http://www.cidoc-crm.org/cidoc-crm/P32_used_general_technique> <https://stad.gent/id/blank_node/0d8f2474-475d-445b-80db-4b7c40c4df9d>.
<https://stad.gent/id/blank_node/80d2f5a1-cd5f-49d0-b20a-44417ab54773> <http://www.cidoc-crm.org/cidoc-crm/P7_took_place_at> <https://stad.gent/id/blank_node/59ddcacf-fc4d-4ec9-8120-79892ef889d3>.
<https://stad.gent/id/blank_node/80d2f5a1-cd5f-49d0-b20a-44417ab54773> <http://www.cidoc-crm.org/cidoc-crm/P24_transferred_title_of> <https://stad.gent/id/mensgemaaktobject/dmg/530002589>.
<https://stad.gent/id/blank_node/80d2f5a1-cd5f-49d0-b20a-44417ab54773> <http://www.cidoc-crm.org/cidoc-crm/P22_transferred_title_to> <http://www.wikidata.org/entity/Q1809071>.
<https://stad.gent/id/blank_node/59ddcacf-fc4d-4ec9-8120-79892ef889d3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Location>.
<https://stad.gent/id/blank_node/59ddcacf-fc4d-4ec9-8120-79892ef889d3> <http://www.cidoc-crm.org/cidoc-crm/P2_has_type> <http://vocab.getty.edu/tgn/7007886>.
<https://stad.gent/id/blank_node/59ddcacf-fc4d-4ec9-8120-79892ef889d3> <http://www.cidoc-crm.org/cidoc-crm/P2_has_type> <https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Plaats_verwervingsbron> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<http://vocab.getty.edu/tgn/7007886> <http://www.w3.org/2004/02/skos/core#prefLabel> """Genk"""@nl.
<https://stad.gent/id/blank_node/0d8f2474-475d-445b-80db-4b7c40c4df9d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept>.
<https://stad.gent/id/blank_node/0d8f2474-475d-445b-80db-4b7c40c4df9d> <http://www.cidoc-crm.org/cidoc-crm/P2_has_type> <https://stad.gent/id/concept/530001021>.
<https://stad.gent/id/blank_node/0d8f2474-475d-445b-80db-4b7c40c4df9d> <http://www.cidoc-crm.org/cidoc-crm/P2_has_type> <https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_verwervingsmethode> <http://www.w3.org/2000/01/rdf-schema#label> """verwerving.methode"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/concept/530001021> <http://www.w3.org/2004/02/skos/core#prefLabel> """aankoop"""@nl.
<https://stad.gent/id/blank_node/d8580ed6-9cbc-4489-972b-1f13821cbbbf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://data.europa.eu/m8g/PeriodOfTime>.
<https://stad.gent/id/blank_node/d8580ed6-9cbc-4489-972b-1f13821cbbbf> <http://data.europa.eu/m8g/startTime> """1998"""^^<http://www.w3.org/2001/XMLSchema#dateTime>.
<https://stad.gent/id/blank_node/d8580ed6-9cbc-4489-972b-1f13821cbbbf> <http://data.europa.eu/m8g/endTime> """1998"""^^<http://www.w3.org/2001/XMLSchema#dateTime>.
<https://stad.gent/id/blank_node/3d13b16d-00e2-4d09-8bdd-a44a7fade41d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E54_Dimension>.
<https://stad.gent/id/blank_node/3d13b16d-00e2-4d09-8bdd-a44a7fade41d> <http://www.cidoc-crm.org/cidoc-crm/P2_has_type> <https://apidg.gent.be/opendata/adlib2eventstream/v1/dmg/diameter>.
<https://stad.gent/id/blank_node/3d13b16d-00e2-4d09-8bdd-a44a7fade41d> <https://schema.org/value> <https://apidg.gent.be/opendata/adlib2eventstream/v1/dmg/14.5>.
<https://stad.gent/id/blank_node/3d13b16d-00e2-4d09-8bdd-a44a7fade41d> <https://schema.org/unitText> """cm"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://stad.gent/id/blank_node/5e640a43-891e-4c83-a9a8-250933ee7d30> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E54_Dimension>.
<https://stad.gent/id/blank_node/5e640a43-891e-4c83-a9a8-250933ee7d30> <http://www.cidoc-crm.org/cidoc-crm/P2_has_type> <https://apidg.gent.be/opendata/adlib2eventstream/v1/dmg/hoogte>.
<https://stad.gent/id/blank_node/5e640a43-891e-4c83-a9a8-250933ee7d30> <https://schema.org/value> <https://apidg.gent.be/opendata/adlib2eventstream/v1/dmg/1.5>.
<https://stad.gent/id/blank_node/5e640a43-891e-4c83-a9a8-250933ee7d30> <https://schema.org/unitText> """cm"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://stad.gent/id/blank_node/d9e99960-198b-4d95-8cc2-3fa50afc279f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept>.
<https://stad.gent/id/blank_node/d9e99960-198b-4d95-8cc2-3fa50afc279f> <http://www.cidoc-crm.org/cidoc-crm/P2_has_type> <http://vocab.getty.edu/aat/300010662>.
<https://stad.gent/id/blank_node/d9e99960-198b-4d95-8cc2-3fa50afc279f> <http://www.cidoc-crm.org/cidoc-crm/P2_has_type> <https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Term_materials> <http://www.w3.org/2000/01/rdf-schema#label> """materiaal"""^^<http://www.w3.org/2001/XMLSchema#string>.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<http://vocab.getty.edu/aat/300010662> <http://www.w3.org/2004/02/skos/core#prefLabel> """porselein"""@nl.
<https://stad.gent/id/blank_node/8ee08357-e62c-4ca4-95d7-98fb22babd78> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.cidoc-crm.org/cidoc-crm/E12_Production>.
<https://stad.gent/id/blank_node/8ee08357-e62c-4ca4-95d7-98fb22babd78> <http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span> """1997/1998"""^^<http://id.loc.gov/datatypes/edtf/EDTF>.
<https://stad.gent/id/blank_node/8ee08357-e62c-4ca4-95d7-98fb22babd78> <http://www.cidoc-crm.org/cidoc-crm/P108_has_produced> <https://stad.gent/id/mensgemaaktobject/dmg/530002589>.
<https://stad.gent/id/blank_node/8ee08357-e62c-4ca4-95d7-98fb22babd78> <http://www.cidoc-crm.org/cidoc-crm/P14_carried_out_by> <https://stad.gent/id/blank_node/a5c682d1-a04c-463c-b4c7-7e6343766fb2>.
<https://stad.gent/id/blank_node/8ee08357-e62c-4ca4-95d7-98fb22babd78> <http://www.cidoc-crm.org/cidoc-crm/P7_took_place_at> <https://stad.gent/id/blank_node/4fad946a-bc1c-4684-900a-c0468746a56d>.
<https://stad.gent/id/blank_node/4fad946a-bc1c-4684-900a-c0468746a56d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/Location>.
<https://stad.gent/id/blank_node/4fad946a-bc1c-4684-900a-c0468746a56d> <https://linked.art/ns/terms/equivalent> <http://vocab.getty.edu/tgn/7007886>.
<https://stad.gent/id/blank_node/4fad946a-bc1c-4684-900a-c0468746a56d> <http://www.cidoc-crm.org/cidoc-crm/P2_has_type> <https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001/XMLSchema#string>.
<https://www.projectcest.be/wiki/Publicatie:Invulboek_objecten/Veld/Naam_plaats_vervaardiging> <http://www.w3.org/2000/01/rdf-schema#label> """vervaardiging.plaats"""^^<http://www.w3.org/2001…