### PR TITLE
blank nodes skolemization now works with immutable quads

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -93,7 +93,7 @@ const consumerJob = new CronJob(CRON_PATTERN, async () => {
       consumer.listen(
         async (member) => {
           try {
-            convertBlankNodes(member.quads);
+            member.quads = convertBlankNodes(member.quads);
             await processMember(member, treeProperties);
           } catch (e) {
             console.error(

--- a/utils.ts
+++ b/utils.ts
@@ -41,21 +41,24 @@ export function fromDate(date: Date): RDF.Literal {
 
 export function convertBlankNodes(quads: RDF.Quad[]) {
   const blankNodesMap = new Map<RDF.BlankNode, RDF.NamedNode>();
-  quads.forEach((quad) => {
+  return quads.map((quad) => {
     if (quad.subject.termType === "BlankNode") {
       if (!blankNodesMap.has(quad.subject)) {
         blankNodesMap.set(quad.subject, BLANK(uuidv4()));
       }
-      quad.subject = blankNodesMap.get(quad.subject)!;
     }
     if (quad.object.termType === "BlankNode") {
       if (!blankNodesMap.has(quad.object)) {
         blankNodesMap.set(quad.object, BLANK(uuidv4()));
       }
-      quad.object = blankNodesMap.get(quad.object)!;
     }
+    if (quad.subject.termType === "BlankNode" || quad.object.termType === "BlankNode") {
+      const newSubject = blankNodesMap.get(quad.subject) || quad.subject;
+      const newObject = blankNodesMap.get(quad.object) || quad.object;
+      return DataFactory.quad(newSubject, quad.predicate, newObject, quad.graph);
+    }
+    return quad;
   });
-  return quads;
 }
 
 export function extractVersionTimestamp (member: Member, treeProperties: TreeProperties) : Date | null {

--- a/utils.ts
+++ b/utils.ts
@@ -56,8 +56,9 @@ export function convertBlankNodes(quads: RDF.Quad[]) {
       const newSubject = blankNodesMap.get(quad.subject) || quad.subject;
       const newObject = blankNodesMap.get(quad.object) || quad.object;
       return DataFactory.quad(newSubject, quad.predicate, newObject, quad.graph);
+    } else {
+      return quad;
     }
-    return quad;
   });
 }
 


### PR DESCRIPTION
Quads are [immutable](https://github.com/rdfjs/data-model-spec/issues/81). This PR makes the blank node skolemization work by creating new quads instead of (trying to) modifying existing ones.