### PR TITLE
Add option to run only once

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ consumer:
 The service can be configured with the following environment variables:
 
 - `BLANK_NODE_NAMESPACE` [string]: namespace to use for skolemizing blank nodes (default 'http://mu.semte.ch/blank#')
+- `AUTOSTART` [boolean]: set to true to start the consumer immediately (e.g. when running the service as a Kubernetes CronJob). It will run only once. (default: `false`)
 - `CRON_PATTERN` [string]: the cron pattern which the cronjob should use. (default: `* 0 * * * *`)
 - `DEBUG_AUTH_HEADERS`: Debugging of [mu-authorization](https://github.com/mu-semtech/mu-authorization) access-control related headers (default `false`)
 - `LDES_ENDPOINT_HEADER_<key>` [string]: A header key-value combination which should be send as part of the headers to the LDES ENDPOINT. E.g. `LDES_ENDPOINT_HEADER_X-API-KEY: <api_key>`.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ consumer:
 The service can be configured with the following environment variables:
 
 - `BLANK_NODE_NAMESPACE` [string]: namespace to use for skolemizing blank nodes (default 'http://mu.semte.ch/blank#')
-- `AUTOSTART` [boolean]: set to true to start the consumer immediately (e.g. when running the service as a Kubernetes CronJob). It will run only once. (default: `false`)
+- `RUNONCE` [boolean]: set to true to run the consumer only once (e.g. when running the service as a Kubernetes CronJob). (default: `false`)
 - `CRON_PATTERN` [string]: the cron pattern which the cronjob should use. (default: `* 0 * * * *`)
 - `DEBUG_AUTH_HEADERS`: Debugging of [mu-authorization](https://github.com/mu-semtech/mu-authorization) access-control related headers (default `false`)
 - `LDES_ENDPOINT_HEADER_<key>` [string]: A header key-value combination which should be send as part of the headers to the LDES ENDPOINT. E.g. `LDES_ENDPOINT_HEADER_X-API-KEY: <api_key>`.

--- a/app.ts
+++ b/app.ts
@@ -11,6 +11,7 @@ import Consumer, { Member } from "ldes-consumer";
 import { TreeProperties, convertBlankNodes, extractBaseResourceUri, extractVersionTimestamp, extractEndpointHeadersFromEnv } from "./utils";
 import { CronJob } from "cron";
 import {
+  AUTOSTART,
   CRON_PATTERN,
   LDES_VERSION_OF_PATH,
   LDES_TIMESTAMP_PATH,
@@ -68,6 +69,13 @@ async function processMember (member: Member, treeProperties: TreeProperties) {
 
 let taskIsRunning = false;
 
+console.log("config", {   CRON_PATTERN,
+                          LDES_VERSION_OF_PATH,
+                          LDES_TIMESTAMP_PATH,
+                          LDES_ENDPOINT_VIEW,
+                          REPLACE_VERSIONS,
+                      });
+
 const consumerJob = new CronJob(CRON_PATTERN, async () => {
   try {
     if (taskIsRunning) {
@@ -113,12 +121,14 @@ const consumerJob = new CronJob(CRON_PATTERN, async () => {
   } catch (e) {
     console.error(e);
   }
-});
+}, async () => {
+  // Shutdown process when running as a Job.
+  if (AUTOSTART) {
+    console.log('Job is complete.');
+    process.exit();
+  }
+}, AUTOSTART);
 
-console.log("config", {   CRON_PATTERN,
-                          LDES_VERSION_OF_PATH,
-                          LDES_TIMESTAMP_PATH,
-                          LDES_ENDPOINT_VIEW,
-                          REPLACE_VERSIONS,
-                      });
-consumerJob.start();
+if (!AUTOSTART) {
+  consumerJob.start();
+}

--- a/app.ts
+++ b/app.ts
@@ -69,13 +69,6 @@ async function processMember (member: Member, treeProperties: TreeProperties) {
 
 let taskIsRunning = false;
 
-console.log("config", {   CRON_PATTERN,
-                          LDES_VERSION_OF_PATH,
-                          LDES_TIMESTAMP_PATH,
-                          LDES_ENDPOINT_VIEW,
-                          REPLACE_VERSIONS,
-                      });
-
 const consumerJob = new CronJob(CRON_PATTERN, async () => {
   try {
     if (taskIsRunning) {
@@ -127,8 +120,15 @@ const consumerJob = new CronJob(CRON_PATTERN, async () => {
     console.log('Job is complete.');
     process.exit();
   }
-}, AUTOSTART);
+});
 
-if (!AUTOSTART) {
-  consumerJob.start();
-}
+console.log("config", {   AUTOSTART,
+                          CRON_PATTERN,
+                          LDES_VERSION_OF_PATH,
+                          LDES_TIMESTAMP_PATH,
+                          LDES_ENDPOINT_VIEW,
+                          REPLACE_VERSIONS,
+                      });
+
+
+consumerJob.start();

--- a/app.ts
+++ b/app.ts
@@ -106,6 +106,11 @@ const consumerJob = new CronJob(CRON_PATTERN, async () => {
           console.log('CONSUMER DONE');
           await updateState(state);
           taskIsRunning = false;
+          // Shutdown process when running as a Job.
+          if (RUNONCE) {
+            console.log('Job is complete.');
+            process.exit();
+          }
         }
       );
     } else {
@@ -113,12 +118,6 @@ const consumerJob = new CronJob(CRON_PATTERN, async () => {
     }
   } catch (e) {
     console.error(e);
-  }
-}, async () => {
-  // Shutdown process when running as a Job.
-  if (RUNONCE) {
-    console.log('Job is complete.');
-    process.exit();
   }
 });
 

--- a/app.ts
+++ b/app.ts
@@ -11,7 +11,7 @@ import Consumer, { Member } from "ldes-consumer";
 import { TreeProperties, convertBlankNodes, extractBaseResourceUri, extractVersionTimestamp, extractEndpointHeadersFromEnv } from "./utils";
 import { CronJob } from "cron";
 import {
-  AUTOSTART,
+  RUNONCE,
   CRON_PATTERN,
   LDES_VERSION_OF_PATH,
   LDES_TIMESTAMP_PATH,
@@ -116,7 +116,7 @@ const consumerJob = new CronJob(CRON_PATTERN, async () => {
   }
 }, async () => {
   // Shutdown process when running as a Job.
-  if (AUTOSTART) {
+  if (RUNONCE) {
     console.log('Job is complete.');
     process.exit();
   }

--- a/app.ts
+++ b/app.ts
@@ -122,7 +122,7 @@ const consumerJob = new CronJob(CRON_PATTERN, async () => {
   }
 });
 
-console.log("config", {   AUTOSTART,
+console.log("config", {   RUNONCE,
                           CRON_PATTERN,
                           LDES_VERSION_OF_PATH,
                           LDES_TIMESTAMP_PATH,

--- a/config.ts
+++ b/config.ts
@@ -1,6 +1,7 @@
 import { PROV, DCTERMS } from "./namespaces";
 import { DataFactory } from "n3";
 const { namedNode } = DataFactory;
+export const AUTOSTART = process.env.AUTOSTART || "false";
 export const CRON_PATTERN = process.env.CRON_PATTERN || "0 * * * * *";
 export const LDES_ENDPOINT_HEADER_PREFIX = "LDES_ENDPOINT_HEADER_";
 export const LDES_ENDPOINT_VIEW = process.env.LDES_ENDPOINT_VIEW;

--- a/config.ts
+++ b/config.ts
@@ -1,7 +1,7 @@
 import { PROV, DCTERMS } from "./namespaces";
 import { DataFactory } from "n3";
 const { namedNode } = DataFactory;
-export const AUTOSTART = process.env.AUTOSTART || "false";
+export const RUNONCE = process.env.RUNONCE || "false";
 export const CRON_PATTERN = process.env.CRON_PATTERN || "0 * * * * *";
 export const LDES_ENDPOINT_HEADER_PREFIX = "LDES_ENDPOINT_HEADER_";
 export const LDES_ENDPOINT_VIEW = process.env.LDES_ENDPOINT_VIEW;


### PR DESCRIPTION
Added option RUNONCE.

It will shutdown the process after running it once.

Useful when running the service as a Kubernetes CronJob:

```
kind: CronJob
apiVersion: batch/v1
metadata:
  name: ldes-consumer-cronjob
spec:
  schedule: '* * * * *'
  concurrencyPolicy: Forbid
  suspend: false
  jobTemplate:
    spec:
      template:
        spec:
          containers:
            - name: ldes-consumer
              env:
                - name: RUNONCE
                  value: true
                - name: CRON_PATTERN
                  value: * * * * * *
              ports:
                - containerPort: 8080
                  protocol: TCP
              imagePullPolicy: IfNotPresent
              image: redpencilio/ldes-consumer
          restartPolicy: OnFailure
          securityContext: {}
          schedulerName: default-scheduler
```