### PR TITLE
batched queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ The service can be configured with the following environment variables:
 - `SPARQL_AUTH_PASSWORD` [string]: provide a passwords to be used in a digest auth to be sent to the SPARQL endpoint.
 - `SPARQL_AUTH_USER` [string]: (optional) provide a username to be used in a digest auth to be sent to the SPARQL endpoint.
 - `SPARQL_ENDPOINT_HEADER_<key>` [string]: A header key-value combination which should be send as part of the headers to the SPARQL ENDPOINT.
+- `SPARQL_BATCH_SIZE` [integer]: amount of triples sent per query. To work around triplestore query-length limitations (default: `0` - disabled).

--- a/config.ts
+++ b/config.ts
@@ -12,3 +12,5 @@ export const REPLACE_VERSIONS = process.env.REPLACE_VERSIONS !== "false";
 export const SPARQL_AUTH_PASSWORD = process.env.SPARQL_AUTH_PASSWORD;
 export const SPARQL_AUTH_USER = process.env.SPARQL_AUTH_USER;
 export const SPARQL_ENDPOINT_HEADER_PREFIX = "SPARQL_ENDPOINT_HEADER_";
+export const SPARQL_BATCH_SIZE = process.env.SPARQL_BATCH_SIZE ? parseInt(process.env.SPARQL_BATCH_SIZE) : 0;
+export const ENABLE_SPARQL_BATCHING = SPARQL_BATCH_SIZE > 0;

--- a/sparql-queries.ts
+++ b/sparql-queries.ts
@@ -90,7 +90,7 @@ export async function executeInsertQuery (quads: RDF.Quad[]) {
     batchSize = SPARQL_BATCH_SIZE;
   } else {
     nBatches = quads.length ? 1 : 0;
-    batchSize = quads.length
+    batchSize = quads.length;
   }
 
   for (let index = 0; index < nBatches; index++) {
@@ -113,7 +113,7 @@ export async function executeDeleteQuery (quads: RDF.Quad[]) {
     batchSize = SPARQL_BATCH_SIZE;
   } else {
     nBatches = quads.length ? 1 : 0;
-    batchSize = quads.length
+    batchSize = quads.length;
   }
   for (let index = 0; index < nBatches; index++) {
     const iQuads = index * batchSize;

--- a/sparql-queries.ts
+++ b/sparql-queries.ts
@@ -83,14 +83,18 @@ async function query (queryStr: string) {
 
 export async function executeInsertQuery (quads: RDF.Quad[]) {
   let nBatches;
+  let batchSize;
   if (ENABLE_SPARQL_BATCHING) {
     nBatches = Math.floor(quads.length / SPARQL_BATCH_SIZE) + ((quads.length % SPARQL_BATCH_SIZE) ? 1 : 0);
+    batchSize = SPARQL_BATCH_SIZE;
   } else {
     nBatches = quads.length ? 1 : 0;
+    batchSize = quads.length
   }
+
   for (let index = 0; index < nBatches; index++) {
-    const iQuads = index * SPARQL_BATCH_SIZE;
-    const quadsBatch = quads.slice(iQuads, iQuads + SPARQL_BATCH_SIZE);
+    const iQuads = index * batchSize;
+    const quadsBatch = quads.slice(iQuads, iQuads + batchSize);
     const queryStr = constructInsertQuery(quadsBatch);
     try {
       await update(queryStr);
@@ -102,14 +106,17 @@ export async function executeInsertQuery (quads: RDF.Quad[]) {
 
 export async function executeDeleteQuery (quads: RDF.Quad[]) {
   let nBatches;
+  let batchSize;
   if (ENABLE_SPARQL_BATCHING) {
     nBatches = Math.floor(quads.length / SPARQL_BATCH_SIZE) + ((quads.length % SPARQL_BATCH_SIZE) ? 1 : 0);
+    batchSize = SPARQL_BATCH_SIZE;
   } else {
     nBatches = quads.length ? 1 : 0;
+    batchSize = quads.length
   }
   for (let index = 0; index < nBatches; index++) {
-    const iQuads = index * SPARQL_BATCH_SIZE;
-    const quadsBatch = quads.slice(iQuads, iQuads + SPARQL_BATCH_SIZE);
+    const iQuads = index * batchSize;
+    const quadsBatch = quads.slice(iQuads, iQuads + batchSize);
     const queryStr = constructDeleteQuery(quadsBatch);
     try {
       await update(queryStr);


### PR DESCRIPTION
Make it possible to configure queries to be batched, to work around store-specific query length limitations.