### PR TITLE
When cronjob is scheduled at a faster rate than the job duration itself, a new task run was run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vscode
+.idea

--- a/app.ts
+++ b/app.ts
@@ -77,16 +77,20 @@ const consumerJob = new CronJob(CRON_PATTERN, async () => {
       console.log("Another task is still running");
       return;
     }
+
     taskIsRunning = true;
     const stream = namedNode(LDES_STREAM);
     const initialState = await fetchState(stream);
     const endpoint = LDES_ENDPOINT_VIEW;
+
     console.log("RUN CONSUMER");
+
     const ldesOptions = {
       dereferenceMembers: LDES_DEREFERENCE_MEMBERS,
       disablePolling: RUNONCE,
       pollingInterval: LDES_POLLING_INTERVAL
     };
+
     if (LDES_REQUESTS_PER_MINUTE) {
       ldesOptions.requestsPerMinute = LDES_REQUESTS_PER_MINUTE;
     }
@@ -131,7 +135,6 @@ const consumerJob = new CronJob(CRON_PATTERN, async () => {
     }
   } catch (e) {
     console.error(e);
-  } finally {
     taskIsRunning = false;
   }
 });


### PR DESCRIPTION
don't in sync javascript code already set the taskIsRunning flag to false ; disable the flag when the async code of the consumer has finished