### PR TITLE
Fix tag filter for woodpecker condition

### DIFF
--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -7,4 +7,4 @@ steps:
     secrets: [docker_username, docker_password]
 when:
   - event: tag
-    tag: v*
+    ref: refs/tags/v*


### PR DESCRIPTION
Woodpecker's `tag:` filter was replaced with `ref:` in version 1.0.0