### PR TITLE
Deprecate `LDES_VERSION_OF_PATH` and `LDES_TIMESTAMP_PATH` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ The service can be configured with the following environment variables:
 | `LDES_REQUESTS_PER_MINUTE` | `0` (unlimited) | How many requests per minutes may be sent to the same host. This is optional, but any passed in value must be a positive number. |
 | `LDES_INFO_REQUEST_TIMEOUT` | `60000` | Number of milliseconds to wait on the LDES info at startup of the stream. If the info is not received in time, the process will be terminated. |
 | `LDES_ENDPOINT_HEADERS` | `{}` (no headers will be added) | Extra headers that will be added to the requests sent to the LDES endpoint. Recommended syntax:<pre>environment:<br>  LDES_ENDPOINT_HEADERS: ><br>    { "HEADER-NAME": "header-value" } # The leading whitespace is important!</pre> |
-| `LDES_VERSION_OF_PATH` | `undefined` (will use LDES feed metadata) | The predicate to be used to find the link to the non version object. If no value is provided and the LDES feed does not provide the metadata, the service will throw an error after starting. |
-| `LDES_TIMESTAMP_PATH` | `undefined` (will use LDES feed metadata) | The predicate to be used to find the timestamp of an object. If no value is provided and the LDES feed does not provide the metadata, the service will throw an error after starting. |
 | `LDES_SANITIZE_CONTENTS_STRING` | N/A | Optional string to search for in fetched LDES pages and replace with LDES_SANITIZE_CONTENTS_REPLACEMENT. For example, allows the removal of invalid content from triples, which would otherwise cause the parser to throw an exception. |
 | `LDES_SANITIZE_CONTENTS_REGEX` | N/A | Optional Regex to search for in fetched LDES pages and replace with LDES_SANITIZE_CONTENTS_REPLACEMENT (ignored if the string form is also passed). For example, allows the removal of invalid content from triples, which would otherwise cause the parser to throw an exception. While this is more flexible than passing a string, it can lead to high memory consumption. Note: special characters need to be escaped for both docker-compose and for node, so to search for `\u` it is necessary to pass `\\\\u` |
 | `LDES_SANITIZE_CONTENTS_REPLACEMENT` | `""` | Optional string to replace sanitized strings with. |
@@ -62,6 +60,9 @@ The service can be configured with the following environment variables:
 | Environment variable | Default | Description |
 |----------------------|---------|-------------|
 | `RUNONCE` | `false` | Set to true to run the consumer only once (e.g. when running the service as a Kubernetes CronJob). Replaced with `RUN_ONCE` environment variable. |
+| `LDES_VERSION_OF_PATH` | `undefined` (will use LDES feed metadata)  | The predicate to be used to find the link to the non version object. The underlying ldes-client does not support this option well and relies on the LDES feed metadata. |
+| `LDES_TIMESTAMP_PATH` | `undefined` (will use LDES feed metadata) | The predicate to be used to find the timestamp of an object. The underlying ldes-client does not support this option well and relies on the LDES feed metadata. |
+
 
 > [!CAUTION]
 > The following environment variables are **no longer supported**:

--- a/cfg.ts
+++ b/cfg.ts
@@ -8,8 +8,12 @@ export const LDES_POLLING_INTERVAL = env.get("LDES_POLLING_INTERVAL").default(60
 export const LDES_REQUESTS_PER_MINUTE = env.get("LDES_REQUESTS_PER_MINUTE").default(0).asIntPositive();
 export const LDES_INFO_REQUEST_TIMEOUT = env.get("LDES_INFO_REQUEST_TIMEOUT").default(60000).asIntPositive();
 export const LDES_ENDPOINT_HEADERS_STRING = env.get("LDES_ENDPOINT_HEADERS").default("{}").asString();
+
+/** @deprecated. The versionOf path should be extracted from the ldes feed */
 export const LDES_VERSION_OF_PATH = env.get("LDES_VERSION_OF_PATH").asString();
+/** @deprecated. The timestamp path should be extracted from the ldes feed */
 export const LDES_TIMESTAMP_PATH = env.get("LDES_TIMESTAMP_PATH").asString();
+
 export const LDES_SANITIZE_CONTENTS_REGEX = env.get("LDES_SANITIZE_CONTENTS_REGEX").asRegExp("g");
 export const LDES_SANITIZE_CONTENTS_STRING = env.get("LDES_SANITIZE_CONTENTS_STRING").asString();
 export const LDES_SANITIZE_CONTENTS_REPLACEMENT = env.get("LDES_SANITIZE_CONTENTS_REPLACEMENT").asString();

--- a/cfg.ts
+++ b/cfg.ts
@@ -2,7 +2,6 @@ import env from 'env-var';
 import { getLoggerFor } from "./lib/logger.ts";
 
 const logger = getLoggerFor("config");
-
 export const LDES_ENDPOINT_VIEW = env.get("LDES_ENDPOINT_VIEW").required().asString();
 export const LDES_POLLING_INTERVAL = env.get("LDES_POLLING_INTERVAL").default(60000).asIntPositive();
 export const LDES_REQUESTS_PER_MINUTE = env.get("LDES_REQUESTS_PER_MINUTE").default(0).asIntPositive();
@@ -11,8 +10,14 @@ export const LDES_ENDPOINT_HEADERS_STRING = env.get("LDES_ENDPOINT_HEADERS").def
 
 /** @deprecated. The versionOf path should be extracted from the ldes feed */
 export const LDES_VERSION_OF_PATH = env.get("LDES_VERSION_OF_PATH").asString();
+if (LDES_VERSION_OF_PATH) {
+  logger.warn("The LDES_VERSION_OF_PATH environment variable is deprecated. The versionOf path should be specified by the ldes feed using the https://w3id.org/ldes#versionOfPath predicate.");
+}
 /** @deprecated. The timestamp path should be extracted from the ldes feed */
 export const LDES_TIMESTAMP_PATH = env.get("LDES_TIMESTAMP_PATH").asString();
+if (LDES_TIMESTAMP_PATH) {
+  logger.warn("The LDES_TIMESTAMP_PATH environment variable is deprecated. The timestamp path should be specified by the ldes feed using the https://w3id.org/ldes#timestampPath predicate.");
+}
 
 export const LDES_SANITIZE_CONTENTS_REGEX = env.get("LDES_SANITIZE_CONTENTS_REGEX").asRegExp("g");
 export const LDES_SANITIZE_CONTENTS_STRING = env.get("LDES_SANITIZE_CONTENTS_STRING").asString();


### PR DESCRIPTION
### Overview
This PR deprecates the `LDES_VERSION_OF_PATH` and `LDES_TIMESTAMP_PATH` options.
These options are a bit confusing/misleading, as they are **NOT** used by the underlying ldes-client library. The underlying library still expects the `versionOfPath` and `timestampPath` to be present in the feed metadata.
These options are a remnant from when a different underlying client was used, which did support these options.

This means that an ldes-feed will (probably) not be consumed correctly when using these options.

### Challenges/uncertainties
These options were not used by any clients (based on a github search)
As I would really not recommend the use of these options, we could alternatively also immediately remove the options and make a breaking release. In addition to this PR, I have also a few other PRs lined up which may introduce deprecations/breaking changes.

