### PR TITLE
DL-7358: add support for not using SUDO queries as well as using scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ The service can be configured with the following environment variables:
 | `SPARQL_AUTH_PASSWORD` | N/A | Optional value to provide a password to be used in a digest auth to be sent to the SPARQL endpoint. |
 | `BLANK_NODE_NAMESPACE` | `http://mu.semte.ch/blank#` | namespace to use for skolemizing blank nodes. |
 | `RUN_ONCE` | `false` | Set to true to run the consumer only once, this disables polling. (useful when running the service as a Kubernetes CronJob).
-| `MU_APPLICATION_GRAPH` | See [semantic.works default graph](https://github.com/mu-semtech/mu-javascript-template/blob/d3281b8dff24502919a75147f7737b83d4dd724f/Dockerfile#L8) | The graph where the data should be ingested. |
+| `MU_APPLICATION_GRAPH` | See [semantic.works default graph](https://github.com/mu-semtech/mu-javascript-template/blob/d3281b8dff24502919a75147f7737b83d4dd724f/Dockerfile#L8) | The graph where the data should be ingested. Note: this parameter is only used if `USE_SUDO_QUERIES` is `true` |
 | `MU_SPARQL_ENDPOINT` | `http://database:8890/sparql` | SPARQL endpoint to connect to. |
+| `USE_SUDO_QUERIES` | `true` | Whether or not to pass the `mu-auth-sudo` header when querying the SPARQL endpoint. |
 | `LOG_SPARQL_ALL` | `false` | Log executed SPARQL queries |
 | `DEBUG_AUTH_HEADERS` | `false` | Debugging of [mu-authorization](https://github.com/mu-semtech/mu-authorization) access-control related headers |
 | `JWT_USE_JWT_AUTH` | `false` | Whether to use a JWT based access token authentication flow when fetching the feed. |

--- a/cfg.ts
+++ b/cfg.ts
@@ -80,6 +80,7 @@ export const RUN_ONCE = RUN_ONCE_VAR || RUNONCE_VAR;
 
 export const MU_APPLICATION_GRAPH = env.get("MU_APPLICATION_GRAPH").required().asString(); // Provided by template
 export const MU_SPARQL_ENDPOINT = env.get("MU_SPARQL_ENDPOINT").required().asString(); // Provided by template
+export const USE_SUDO_QUERIES = env.get("USE_SUDO_QUERIES").default("true").asBool();
 export const DEBUG_AUTH_HEADERS = env.get("DEBUG_AUTH_HEADERS").default("false").asBool();
 
 export const NODE_ENV = env.get("NODE_ENV").default("production").asEnum(["development", "production"]);

--- a/config/process-member.ts
+++ b/config/process-member.ts
@@ -1,6 +1,6 @@
 import type { Client } from "ldes-client";
 import { DataFactory } from "n3";
-import { convertBlankNodes } from "../lib/utils.ts";
+import { convertBlankNodes } from "../lib/utils/rdf.ts";
 // eslint-disable-next-line n/no-missing-import
 import { Quad, Term } from "@rdfjs/types";
 import { INGEST_MODE, REPLACE_VERSIONS } from "../cfg.ts";

--- a/lib/database-helpers.ts
+++ b/lib/database-helpers.ts
@@ -1,4 +1,4 @@
-import { query } from 'mu';
+import { query } from "./sparql-queries.ts";
 
 const PING_DB_INTERVAL_MILLIS = 2000;
 

--- a/lib/sparql-queries.ts
+++ b/lib/sparql-queries.ts
@@ -68,7 +68,7 @@ export function constructSelectQuery(
 export async function update (queryStr: string) {
   const headers : Record<string, number | string | string[]> = SPARQL_ENDPOINT_HEADERS ?? {};
   if (SPARQL_AUTH_USER && SPARQL_AUTH_PASSWORD) {
-    headers['Authorization'] = btoa(SPARQL_AUTH_USER + ':' + SPARQL_AUTH_PASSWORD); 
+    headers['Authorization'] = `Basic ${btoa(SPARQL_AUTH_USER + ':' + SPARQL_AUTH_PASSWORD)}`; 
   }
   return await muUpdate(queryStr, { extraHeaders: headers, sudo: USE_SUDO_QUERIES })
 }

--- a/lib/sparql-queries.ts
+++ b/lib/sparql-queries.ts
@@ -9,8 +9,9 @@ import {
   ENABLE_SPARQL_BATCHING
 } from "../cfg.ts";
 
-// @ts-expect-error has no type declarations
-import { querySudo, updateSudo, ConnectionOptions } from "@lblod/mu-auth-sudo";
+ 
+// eslint-disable-next-line n/no-missing-import
+import { update as muUpdate, query as muQuery } from './utils/sparql.js'
 
 const SPARQL_ENDPOINT_HEADERS = extractEndpointHeadersFromEnv(SPARQL_ENDPOINT_HEADER_PREFIX);
 
@@ -62,25 +63,21 @@ export function constructSelectQuery (
   return sparqlQuery;
 }
 
-async function update (queryStr: string) {
+export async function update (queryStr: string) {
   const headers : Record<string, number | string | string[]> = SPARQL_ENDPOINT_HEADERS ?? {};
-  const connectionOptions : ConnectionOptions = {};
   if (SPARQL_AUTH_USER && SPARQL_AUTH_PASSWORD) {
-    connectionOptions.authUser = SPARQL_AUTH_USER;
-    connectionOptions.authPassword = SPARQL_AUTH_PASSWORD;
+    headers['Authorization'] = btoa(SPARQL_AUTH_USER + ':' + SPARQL_AUTH_PASSWORD); 
   }
-  return await updateSudo(queryStr, headers, connectionOptions);
+  return await muUpdate(queryStr, { extraHeaders: headers, sudo: true })
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function query (queryStr: string) {
+ 
+export async function query (queryStr: string) {
   const headers : Record<string, number | string | string[]> = SPARQL_ENDPOINT_HEADERS ?? {};
-  const connectionOptions : ConnectionOptions = {};
   if (SPARQL_AUTH_USER && SPARQL_AUTH_PASSWORD) {
-    connectionOptions.authUser = SPARQL_AUTH_USER;
-    connectionOptions.authPassword = SPARQL_AUTH_PASSWORD;
+    headers['Authorization'] = btoa(SPARQL_AUTH_USER + ':' + SPARQL_AUTH_PASSWORD); 
   }
-  return await querySudo(queryStr, headers, connectionOptions);
+  return await muQuery(queryStr, { extraHeaders: headers, sudo: true });
 }
 
 export async function executeInsertQuery (quads: RDF.Quad[]) {

--- a/lib/sparql-queries.ts
+++ b/lib/sparql-queries.ts
@@ -1,65 +1,67 @@
 import type * as RDF from "@rdfjs/types";
-import { extractEndpointHeadersFromEnv, toString } from "./utils.ts";
+import { extractEndpointHeadersFromEnv } from "./utils/http.ts";
+import { toString } from "./utils/rdf.ts";
 import {
   MU_APPLICATION_GRAPH,
   SPARQL_AUTH_USER,
   SPARQL_AUTH_PASSWORD,
   SPARQL_ENDPOINT_HEADER_PREFIX,
   SPARQL_BATCH_SIZE,
-  ENABLE_SPARQL_BATCHING
+  ENABLE_SPARQL_BATCHING,
+  USE_SUDO_QUERIES,
 } from "../cfg.ts";
 
- 
 // eslint-disable-next-line n/no-missing-import
 import { update as muUpdate, query as muQuery } from './utils/sparql.js'
 
-const SPARQL_ENDPOINT_HEADERS = extractEndpointHeadersFromEnv(SPARQL_ENDPOINT_HEADER_PREFIX);
+const SPARQL_ENDPOINT_HEADERS = extractEndpointHeadersFromEnv(
+  SPARQL_ENDPOINT_HEADER_PREFIX,
+);
 
-function constructTriplesString (quads: RDF.Quad[]) {
-  const triplesString = quads.map(toString)
+function constructTriplesString(quads: RDF.Quad[]) {
+  const triplesString = quads
+    .map(toString)
     .filter((item, index, array) => array.indexOf(item) === index)
     .join("\n        ");
   return triplesString;
 }
 
-export function constructInsertQuery (quads: RDF.Quad[]) {
+function wrapInGraphIfRequired(body: string): string {
+  return USE_SUDO_QUERIES
+    ? `GRAPH <${MU_APPLICATION_GRAPH}> {\n  ${body}\n}`
+    : body;
+}
+
+export function constructInsertQuery(quads: RDF.Quad[]) {
   const triplesString = constructTriplesString(quads);
-  const sparqlQuery = `INSERT DATA {
-    GRAPH <${MU_APPLICATION_GRAPH}> {
-        ${triplesString}
-    }
-}`;
+  const sparqlQuery = 
+    `INSERT DATA {
+        ${wrapInGraphIfRequired(triplesString)}
+    }`;
   return sparqlQuery;
 }
 
-export function constructDeleteQuery (quads: RDF.Quad[]) {
+export function constructDeleteQuery(quads: RDF.Quad[]) {
   const triplesString = constructTriplesString(quads);
-  const sparqlQuery = `DELETE {
-    GRAPH <${MU_APPLICATION_GRAPH}> {
-          ${triplesString}
-    }
-} WHERE {
-    GRAPH <${MU_APPLICATION_GRAPH}> {
-        ${triplesString}
-    }
-}`;
+  const sparqlQuery = 
+    `DELETE WHERE {
+        ${wrapInGraphIfRequired(triplesString)}
+    }`;
   return sparqlQuery;
 }
 
-export function constructSelectQuery (
+export function constructSelectQuery(
   variables: RDF.Variable[],
   quads: RDF.Quad[],
-  orderBy?: string
+  orderBy?: string,
 ) {
   const triplesString = constructTriplesString(quads);
   const variablesString = variables.map(toString).join(" ");
-  const sparqlQuery = `
-    SELECT DISTINCT ${variablesString} WHERE {
-      GRAPH <${MU_APPLICATION_GRAPH}> {
-        ${triplesString}
-      }
+  const sparqlQuery = 
+    `SELECT DISTINCT ${variablesString} WHERE {
+      ${wrapInGraphIfRequired(triplesString)}
     }
-    ${orderBy ? orderBy : ''}`;
+    ${orderBy ?? ""}`;
   return sparqlQuery;
 }
 
@@ -68,23 +70,25 @@ export async function update (queryStr: string) {
   if (SPARQL_AUTH_USER && SPARQL_AUTH_PASSWORD) {
     headers['Authorization'] = btoa(SPARQL_AUTH_USER + ':' + SPARQL_AUTH_PASSWORD); 
   }
-  return await muUpdate(queryStr, { extraHeaders: headers, sudo: true })
+  return await muUpdate(queryStr, { extraHeaders: headers, sudo: USE_SUDO_QUERIES })
 }
 
  
 export async function query (queryStr: string) {
   const headers : Record<string, number | string | string[]> = SPARQL_ENDPOINT_HEADERS ?? {};
   if (SPARQL_AUTH_USER && SPARQL_AUTH_PASSWORD) {
-    headers['Authorization'] = btoa(SPARQL_AUTH_USER + ':' + SPARQL_AUTH_PASSWORD); 
+    headers['Authorization'] = `Basic ${btoa(SPARQL_AUTH_USER + ':' + SPARQL_AUTH_PASSWORD)}`; 
   }
-  return await muQuery(queryStr, { extraHeaders: headers, sudo: true });
+  return await muQuery(queryStr, { extraHeaders: headers, sudo: USE_SUDO_QUERIES });
 }
 
-export async function executeInsertQuery (quads: RDF.Quad[]) {
+export async function executeInsertQuery(quads: RDF.Quad[]) {
   let nBatches;
   let batchSize;
   if (ENABLE_SPARQL_BATCHING) {
-    nBatches = Math.floor(quads.length / SPARQL_BATCH_SIZE) + ((quads.length % SPARQL_BATCH_SIZE) ? 1 : 0);
+    nBatches =
+      Math.floor(quads.length / SPARQL_BATCH_SIZE) +
+      (quads.length % SPARQL_BATCH_SIZE ? 1 : 0);
     batchSize = SPARQL_BATCH_SIZE;
   } else {
     nBatches = quads.length ? 1 : 0;
@@ -99,11 +103,13 @@ export async function executeInsertQuery (quads: RDF.Quad[]) {
   }
 }
 
-export async function executeDeleteQuery (quads: RDF.Quad[]) {
+export async function executeDeleteQuery(quads: RDF.Quad[]) {
   let nBatches;
   let batchSize;
   if (ENABLE_SPARQL_BATCHING) {
-    nBatches = Math.floor(quads.length / SPARQL_BATCH_SIZE) + ((quads.length % SPARQL_BATCH_SIZE) ? 1 : 0);
+    nBatches =
+      Math.floor(quads.length / SPARQL_BATCH_SIZE) +
+      (quads.length % SPARQL_BATCH_SIZE ? 1 : 0);
     batchSize = SPARQL_BATCH_SIZE;
   } else {
     nBatches = quads.length ? 1 : 0;
@@ -117,9 +123,9 @@ export async function executeDeleteQuery (quads: RDF.Quad[]) {
   }
 }
 
-export async function executeDeleteInsertQuery (
+export async function executeDeleteInsertQuery(
   quadsToDelete: RDF.Quad[],
-  quadsToInsert: RDF.Quad[]
+  quadsToInsert: RDF.Quad[],
 ) {
   await executeDeleteQuery(quadsToDelete);
   await executeInsertQuery(quadsToInsert);

--- a/lib/utils/http.ts
+++ b/lib/utils/http.ts
@@ -1,0 +1,12 @@
+export function extractEndpointHeadersFromEnv(prefix: string) {
+  const headers: Record<string, number | string | string[]> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.startsWith(prefix)) {
+      const headerKey = key.split(prefix).pop();
+      if (headerKey && value) {
+        headers[headerKey.toLowerCase()] = value;
+      }
+    }
+  }
+  return headers;
+}

--- a/lib/utils/rdf.ts
+++ b/lib/utils/rdf.ts
@@ -1,23 +1,23 @@
 import type * as RDF from "@rdfjs/types";
-import { BLANK } from "./namespaces.ts";
+import { BLANK } from "../namespaces.ts";
 
 import { v4 as uuidv4 } from "uuid";
 
 import { sparqlEscapeString, sparqlEscapeUri } from "mu";
 import { DataFactory } from "n3";
 
-export function toString(term: RDF.Term): string {
+export function toString (term: RDF.Term): string {
   switch (term.termType) {
     case "NamedNode":
       return sparqlEscapeUri(term.value);
     case "Literal":
-      {
-        let result = sparqlEscapeString(term.value);
+    {
+      let result = sparqlEscapeString(term.value);
 
-        if (term.language) result += `@${term.language}`;
-        else if (term.datatype) { result += `^^${sparqlEscapeUri(term.datatype.value)}`; }
-        return result;
-      }
+      if (term.language) result += `@${term.language}`;
+      else if (term.datatype) { result += `^^${sparqlEscapeUri(term.datatype.value)}`; }
+      return result;
+    }
     case "Quad":
       return `${toString(term.subject)} ${toString(
         term.predicate
@@ -29,7 +29,7 @@ export function toString(term: RDF.Term): string {
   }
 }
 
-export function convertBlankNodes(quads: RDF.Quad[]) {
+export function convertBlankNodes (quads: RDF.Quad[]) {
   const blankNodesMap = new Map<RDF.Term, RDF.NamedNode>();
   return quads.map((quad) => {
     if (quad.subject.termType === "BlankNode") {
@@ -50,17 +50,4 @@ export function convertBlankNodes(quads: RDF.Quad[]) {
       return quad;
     }
   });
-}
-
-export function extractEndpointHeadersFromEnv(prefix: string) {
-  const headers: Record<string, number | string | string[]> = {};
-  for (const [key, value] of Object.entries(process.env)) {
-    if (key.startsWith(prefix)) {
-      const headerKey = key.split(prefix).pop();
-      if (headerKey && value) {
-        headers[headerKey.toLowerCase()] = value;
-      }
-    }
-  }
-  return headers;
 }

--- a/lib/utils/sparql-tag.js
+++ b/lib/utils/sparql-tag.js
@@ -1,0 +1,20 @@
+import Term from "./term.js";
+
+/**
+ * ECMAScript 2015 tagged template function for building safe SPARQL queries.
+ *
+ * Interpolated values are converted to their SPARQL representation using
+ * Term.create so they are properly escaped and typed.
+ *
+ * @example
+ * const name = "O'Brien";
+ * const query = SPARQL`SELECT * WHERE { ?s foaf:name ${name} }`;
+ * // name becomes """O'Brien"""
+ */
+export default function SPARQL (template, ...substitutions) {
+  let result = template[0];
+  substitutions.forEach((value, i) => {
+    result += Term.create(value).format() + template[i + 1];
+  });
+  return result;
+}

--- a/lib/utils/sparql.js
+++ b/lib/utils/sparql.js
@@ -1,0 +1,333 @@
+/**
+ * Copied from https://github.com/mu-semtech/mu-javascript-template/pull/82
+ * At the time of adding this code, the above PR was not merged yet.
+ * In comparison to the SPARQL client used in the release version of the `mu-javascript-template` image (at the time of writing, version https://github.com/mu-semtech/mu-javascript-template/releases/tag/v1.9.1),
+ * this client supports sending custom headers to the SPARQL endpoint.
+ * 
+ */
+
+import httpContext from "express-http-context";
+import env from "env-var";
+import SPARQL from "./sparql-tag.js";
+
+const LOG_SPARQL_QUERIES = process.env.LOG_SPARQL_QUERIES != undefined ? env.get("LOG_SPARQL_QUERIES").asBool() : env.get("LOG_SPARQL_ALL").asBool();
+const LOG_SPARQL_UPDATES = process.env.LOG_SPARQL_UPDATES != undefined ? env.get("LOG_SPARQL_UPDATES").asBool() : env.get("LOG_SPARQL_ALL").asBool();
+const DEBUG_AUTH_HEADERS = env.get("DEBUG_AUTH_HEADERS").asBool();
+const MU_SPARQL_ENDPOINT = process.env.MU_SPARQL_ENDPOINT || "http://database:8890/sparql";
+
+//= =-- logic --==//
+
+/**
+ * Execute a sparql QUERY.  Intended for use with SELECT and ASK.
+ *
+ * See environment variables for logging: `LOG_SPARQL_ALL`, `LOG_SPARQL_QUERIES`, `DEBUG_AUTH_HEADERS`
+ *
+ * @param { string } queryString SPARQL query as a string.
+ * @param { QueryOptions? } options Operational changes to the SPARQL query.
+ * @return { Promise<object?> } The response is returned as a parsed JSON object, or null if the response could not be parsed as JSON.
+ */
+function query (queryString, options = {}) {
+  if (LOG_SPARQL_QUERIES) {
+    console.log(queryString);
+  }
+  return executeQuery(queryString, options);
+}
+
+/**
+ * Execute a sparql UPDATE.
+ * Intended for use with `DELETE {} INSERT {} WHERE {}`, `INSERT DATA` and `DELETE DATA`.
+ *
+ * See environment variables for logging: `LOG_SPARQL_ALL`, `LOG_SPARQL_UPDATES`, `DEBUG_AUTH_HEADERS`
+ *
+ * @param { string } queryString SPARQL query as a string.
+ * @param { QueryOptions? } options Operational changes to the SPARQL query.
+ * @return { Promise<object?> } The response is returned as a parsed JSON object, or null if the response could not be parsed as JSON.
+ */
+function update (queryString, options = {}) {
+  if (LOG_SPARQL_UPDATES) {
+    console.log(queryString);
+  }
+  return executeQuery(queryString, options);
+}
+
+/**
+ * Build the default headers for a SPARQL request from the current HTTP
+ * context, forwarding mu-auth headers so mu-authorization can apply the
+ * correct access rules.
+ */
+function defaultHeaders () {
+  const headers = new Headers();
+  headers.set("content-type", "application/x-www-form-urlencoded");
+  headers.set("Accept", "application/sparql-results+json");
+
+  const req = httpContext.get("request");
+  if (req) {
+    const muSessionId = req.get("mu-session-id");
+    if (muSessionId) headers.set("mu-session-id", muSessionId);
+
+    const muCallId = req.get("mu-call-id");
+    if (muCallId) headers.set("mu-call-id", muCallId);
+
+    // Forward allowed-groups from the incoming request so mu-authorization
+    // does not have to recompute them on every SPARQL call.
+    const allowedGroups = req.get("mu-auth-allowed-groups");
+    if (allowedGroups) headers.set("mu-auth-allowed-groups", allowedGroups);
+  }
+
+  const res = httpContext.get("response");
+  if (res) {
+    // If a previous SPARQL query within this request already resolved the
+    // allowed groups, forward them to avoid redundant lookups.
+    const allowedGroups = res.get("mu-auth-allowed-groups");
+    if (allowedGroups) headers.set("mu-auth-allowed-groups", allowedGroups);
+  }
+
+  return headers;
+}
+
+/**
+ * @typedef {Object} QueryOptions
+ * @property {boolean?} sudo Execute the query with mu-auth-sudo privileges.
+ * @property {string?}  scope URI of the scope to use.  Falls back to the DEFAULT_MU_AUTH_SCOPE environment variable.
+ * @property {object?}  extraHeaders Additional headers to include in the request.
+ */
+
+/**
+ * Send a SPARQL query to the configured endpoint and return the parsed JSON
+ * response.
+ *
+ * @param { string } queryString SPARQL query as a string.
+ * @param { QueryOptions? } options Operational changes to the SPARQL query.
+ * @return { Promise<object?> } The response is returned as a parsed JSON object, or null if the response could not be parsed as JSON.
+ */
+async function executeQuery (queryString, options = {}) {
+  const headers = defaultHeaders();
+
+  const extraHeaders = options.extraHeaders ?? {};
+  for (const key of Object.keys(extraHeaders)) {
+    headers.append(key, extraHeaders[key]);
+  }
+
+  if (options.sudo === true) {
+    if (env.get("ALLOW_MU_AUTH_SUDO").asBool()) {
+      headers.set("mu-auth-sudo", "true");
+    } else {
+      throw new Error("sudo query requested but ALLOW_MU_AUTH_SUDO is not set");
+    }
+  }
+
+  if (options.scope) {
+    headers.set("mu-auth-scope", options.scope);
+  } else if (process.env.DEFAULT_MU_AUTH_SCOPE) {
+    headers.set("mu-auth-scope", process.env.DEFAULT_MU_AUTH_SCOPE);
+  }
+
+  if (DEBUG_AUTH_HEADERS) {
+    const muHeaders = Array.from(headers.entries())
+      .filter(([key]) => key.startsWith("mu-"))
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(", ");
+    console.log(`SPARQL request mu-headers: ${muHeaders}`);
+  }
+
+  const formData = new URLSearchParams();
+  formData.set("query", queryString);
+
+  try {
+    const response = await fetch(MU_SPARQL_ENDPOINT, {
+      method: "POST",
+      body: formData.toString(),
+      headers
+    });
+
+    updateResponseHeaders(response);
+
+    if (!response.ok) {
+      throw new Error(`SPARQL endpoint returned HTTP ${response.status} ${response.statusText}`);
+    }
+
+    return await maybeJSON(response);
+  } catch (ex) {
+    console.log(`Failed Query:
+${queryString}`);
+    throw ex;
+  }
+}
+
+/**
+ * Copy mu-auth group headers from the SPARQL response back onto the outgoing
+ * HTTP response so the client receives up-to-date group information.
+ */
+function updateResponseHeaders (response) {
+  const res = httpContext.get("response");
+  if (!res || res.headersSent) return;
+
+  const allowedGroups = response.headers.get("mu-auth-allowed-groups");
+  if (allowedGroups) {
+    res.setHeader("mu-auth-allowed-groups", allowedGroups);
+    if (DEBUG_AUTH_HEADERS) console.log(`Forwarded mu-auth-allowed-groups: ${allowedGroups}`);
+  } else {
+    res.removeHeader("mu-auth-allowed-groups");
+    if (DEBUG_AUTH_HEADERS) console.log("Removed mu-auth-allowed-groups from response");
+  }
+
+  const usedGroups = response.headers.get("mu-auth-used-groups");
+  if (usedGroups) {
+    res.setHeader("mu-auth-used-groups", usedGroups);
+    if (DEBUG_AUTH_HEADERS) console.log(`Forwarded mu-auth-used-groups: ${usedGroups}`);
+  } else {
+    res.removeHeader("mu-auth-used-groups");
+    if (DEBUG_AUTH_HEADERS) console.log("Removed mu-auth-used-groups from response");
+  }
+}
+
+async function maybeJSON (response) {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Escapes a string for use in SPARQL.
+ *
+ * Wraps the string in quotes and escapes necessary characters.
+ *
+ * @param {string} value String to be escaped.
+ * @return {string} Escaped string for use in SPARQL.
+ */
+function sparqlEscapeString (value) {
+  return "\"\"\"" + value.replace(/[\\"]/g, function (match) { return "\\" + match; }) + "\"\"\"";
+};
+
+/**
+ * Escapes a URI for use in SPARQL.
+ *
+ * Wraps the URI in < and > and escapes necessary characters.
+ *
+ * @param {string} value URI string to be escaped.
+ * @return {string} Escaped URI string for use in SPARQL.
+ */
+function sparqlEscapeUri (value) {
+  return "<" + value.replace(/[\\"<>]/g, function (match) { return "\\" + match; }) + ">";
+};
+
+/**
+ * Escapes a float for use in SPARQL as xsd:decimal.
+ *
+ * @param {string|number} value Number string or value to be escaped.
+ * @return {string} Escaped number for use in SPARQL.
+ */
+function sparqlEscapeDecimal (value) {
+  return "\"" + Number.parseFloat(value) + "\"^^xsd:decimal";
+};
+
+/**
+ * Escapes an integer for use in SPARQL as xsd:integer.
+ *
+ * @param {string|number} value Number string or value to be escaped.
+ * @return {string} Escaped number for use in SPARQL.
+ */
+function sparqlEscapeInt (value) {
+  return "\"" + Number.parseInt(value) + "\"^^xsd:integer";
+};
+
+/**
+ * Escapes a number for use in SPARQL as xsd:float.
+ *
+ * @param {string|number} value Number string or value to be escaped.
+ * @return {string} Escaped number for use in SPARQL.
+ */
+function sparqlEscapeFloat (value) {
+  return "\"" + Number.parseFloat(value) + "\"^^xsd:float";
+};
+
+/**
+ * Escapes a date string or date object into an xsd:date for use in SPARQL.
+ *
+ * @param {string|Date|number} value Number string or value to be escaped.
+ * @return {string} Escaped number for use in SPARQL.
+ */
+function sparqlEscapeDate (value) {
+  return "\"" + new Date(value).toISOString().substring(0, 10) + "\"^^xsd:date"; // only keep 'YYYY-MM-DD' portion of the string
+};
+
+/**
+ * Escape date string or date object into an xsd:dateTime for use in a SPARQL string.
+ *
+ * @param { Date | string | number } value Date representation
+ * (understood by `new Date`) to convert.
+ * @return { string } Date representation for SPARQL query.
+ */
+function sparqlEscapeDateTime (value) {
+  return "\"" + new Date(value).toISOString() + "\"^^xsd:dateTime";
+};
+
+/**
+ * Escape boolean-like value into xsd:boolean for use in a SPARQL string.
+ *
+ * @param { any } value Boolean-like value, anything javascript finds truethy is true.
+ * @return { string } Boolean representation for SPARQL query.
+ */
+function sparqlEscapeBool (value) {
+  return value ? "\"true\"^^xsd:boolean" : "\"false\"^^xsd:boolean";
+};
+
+function sparqlEscape (value, type) {
+  switch (type) {
+    case "string":
+      return sparqlEscapeString(value);
+    case "uri":
+      return sparqlEscapeUri(value);
+    case "bool":
+      return sparqlEscapeBool(value);
+    case "decimal":
+      return sparqlEscapeDecimal(value);
+    case "int":
+      return sparqlEscapeInt(value);
+    case "float":
+      return sparqlEscapeFloat(value);
+    case "date":
+      return sparqlEscapeDate(value);
+    case "dateTime":
+      return sparqlEscapeDateTime(value);
+    default:
+      console.error(`WARN: Unknown escape type '${type}'. Escaping as string`);
+      return sparqlEscapeString(value);
+  }
+}
+
+//= =-- exports --==//
+const exports = {
+  SPARQL,
+  sparql: SPARQL,
+  query,
+  update,
+  sparqlEscape,
+  sparqlEscapeString,
+  sparqlEscapeUri,
+  sparqlEscapeDecimal,
+  sparqlEscapeInt,
+  sparqlEscapeFloat,
+  sparqlEscapeDate,
+  sparqlEscapeDateTime,
+  sparqlEscapeBool
+};
+export default exports;
+
+export {
+  SPARQL,
+  SPARQL as sparql,
+  query,
+  update,
+  sparqlEscape,
+  sparqlEscapeString,
+  sparqlEscapeUri,
+  sparqlEscapeDecimal,
+  sparqlEscapeInt,
+  sparqlEscapeFloat,
+  sparqlEscapeDate,
+  sparqlEscapeDateTime,
+  sparqlEscapeBool
+};

--- a/lib/utils/sparql.js
+++ b/lib/utils/sparql.js
@@ -87,9 +87,9 @@ function defaultHeaders () {
 
 /**
  * @typedef {Object} QueryOptions
- * @property {boolean?} sudo Execute the query with mu-auth-sudo privileges.
- * @property {string?}  scope URI of the scope to use.  Falls back to the DEFAULT_MU_AUTH_SCOPE environment variable.
- * @property {object?}  extraHeaders Additional headers to include in the request.
+ * @property {boolean?} [sudo] Execute the query with mu-auth-sudo privileges.
+ * @property {string?}  [scope] URI of the scope to use.  Falls back to the DEFAULT_MU_AUTH_SCOPE environment variable.
+ * @property {object?}  [extraHeaders] Additional headers to include in the request.
  */
 
 /**
@@ -97,7 +97,7 @@ function defaultHeaders () {
  * response.
  *
  * @param { string } queryString SPARQL query as a string.
- * @param { QueryOptions? } options Operational changes to the SPARQL query.
+ * @param { QueryOptions? } [options] Operational changes to the SPARQL query.
  * @return { Promise<object?> } The response is returned as a parsed JSON object, or null if the response could not be parsed as JSON.
  */
 async function executeQuery (queryString, options = {}) {

--- a/lib/utils/term.js
+++ b/lib/utils/term.js
@@ -1,0 +1,228 @@
+/**
+ * RDF Term types for use in SPARQL template literal interpolation.
+ *
+ * This software incorporates code derived from node-sparql-client
+ * (https://github.com/eddieantonio/node-sparql-client), MIT License.
+ *
+ * Adapted from the original: merged into a single ESM file to eliminate
+ * circular module dependencies, and modernised to ES2015 class syntax.
+ */
+
+// ── Term (abstract base) ─────────────────────────────────────────────────────
+
+class Term {
+  format () {
+    throw new Error("term MUST implement a #format method!");
+  }
+}
+
+// ── IRI ──────────────────────────────────────────────────────────────────────
+
+class IRI extends Term {
+  /**
+   * Creates an IRI from a string or a single-key object {prefix: localname}.
+   */
+  static create (value) {
+    if (typeof value === "string") return new IRIReference(value);
+    if (typeof value === "object" && value !== null) return IRI.createFromObject(value);
+    throw new TypeError("Invalid IRI: expected string or object, got " + typeof value);
+  }
+
+  static createFromObject (object) {
+    const keys = Object.keys(object);
+    if (keys.length !== 1) throw new Error("Invalid prefixed IRI: object must have exactly one key.");
+    const namespace = keys[0];
+    const local = object[namespace];
+    if (typeof local !== "string") throw new TypeError("Invalid prefixed IRI: local name must be a string.");
+    if (!/^[^\s;.,<|$]+$/.test(local)) throw new Error("Invalid IRI identifier: " + local);
+    return new PrefixedNameIRI(namespace, local);
+  }
+}
+
+class PrefixedNameIRI extends IRI {
+  constructor (namespace, id) {
+    super();
+    this.namespace = namespace;
+    this.id = id;
+  }
+
+  format () {
+    return this.namespace + ":" + this.id;
+  }
+}
+
+class IRIReference extends IRI {
+  constructor (iri) {
+    super();
+    /* Reject characters forbidden in IRIREF per SPARQL 1.1 spec:
+     * < > " { } | ^ backtick backslash and codepoints 0x00-0x20 */
+    if (/[<>"{}|^`\\]/.test(iri) || [...iri].some(ch => ch.codePointAt(0) <= 0x20)) {
+      throw new Error("Invalid IRI: " + iri);
+    }
+    this.iri = iri;
+  }
+
+  format () {
+    return "<" + this.iri + ">";
+  }
+}
+
+// ── Literal ──────────────────────────────────────────────────────────────────
+
+const SPARQL_LITERAL_PATTERNS = {
+  boolean: /^true$|^false$/,
+  integer: /^[-+]?[0-9]+$/,
+  double: /^[-+]?(?:[0-9]+\.[0-9]*|\.[0-9]+|[0-9]+)[eE][+-]?[0-9]+$/,
+  decimal: /^[-+]?[0-9]*\.[0-9]+$/
+};
+
+class Literal extends Term {
+  constructor (value, datatype) {
+    super();
+    this.value = "" + value;
+    if (datatype !== undefined) {
+      this.datatype = IRI.create(datatype);
+    }
+  }
+
+  static create (value) {
+    return new StringLiteral(value);
+  }
+
+  static createWithLanguageTag (value, languageTag) {
+    if (typeof languageTag !== "string") {
+      throw new TypeError("Language tag must be a string.");
+    }
+    return new StringLiteral(value, languageTag);
+  }
+
+  /** @deprecated Use createWithLanguageTag (fixes typo in original API name). */
+  static createWithLangaugeTag (value, languageTag) {
+    return Literal.createWithLanguageTag(value, languageTag);
+  }
+
+  static createWithDataType (value, datatype) {
+    if (datatype === undefined) throw new TypeError("Undefined datatype provided.");
+    return new Literal(value, datatype);
+  }
+
+  format () {
+    if (isKnownXsdDatatype(this.datatype)) {
+      const term = tryFormatXsdType(this.value, this.datatype.id);
+      if (term !== undefined) {
+        return term.wrapAsString
+          ? formatStringWithDataType(term.literal, this.datatype)
+          : term.literal;
+      }
+    }
+    return formatStringWithDataType(this.value, this.datatype);
+  }
+}
+
+class StringLiteral extends Literal {
+  constructor (value, languageTag) {
+    super(value);
+    if (languageTag !== undefined) {
+      if (!/^[a-zA-Z]+(?:-[a-zA-Z0-9]+)*$/.test(languageTag)) {
+        throw new Error("Invalid language tag: " + languageTag);
+      }
+      this.languageTag = languageTag;
+    }
+  }
+
+  format () {
+    const str = formatRDFString(this.value);
+    return this.languageTag !== undefined ? str + "@" + this.languageTag : str;
+  }
+}
+
+function isKnownXsdDatatype (iri) {
+  return iri != null && iri.namespace === "xsd" && iri.id in SPARQL_LITERAL_PATTERNS;
+}
+
+function tryFormatXsdType (value, type) {
+  const stringified = "" + value;
+  if (type === "double") {
+    if (Math.abs(+value) === Infinity) {
+      return { literal: (value < 0 ? "-" : "") + "INF", wrapAsString: true };
+    }
+    if (SPARQL_LITERAL_PATTERNS.double.test(stringified)) return { literal: stringified };
+    const withExponent = stringified + "e0";
+    if (SPARQL_LITERAL_PATTERNS.double.test(withExponent)) return { literal: withExponent };
+    return undefined;
+  }
+  if (SPARQL_LITERAL_PATTERNS[type].test(stringified)) return { literal: stringified };
+}
+
+/**
+ * Formats a string value as a SPARQL RDF literal.
+ * Uses triple double-quotes to support newlines and most special characters;
+ * only backslash and embedded triple-quote sequences need escaping.
+ */
+function formatRDFString (value) {
+  const str = "" + value;
+  const escaped = str
+    .replace(/\\/g, "\\\\")
+    .replace(/"""/g, "\"\"\\\"");
+  return "\"\"\"" + escaped + "\"\"\"";
+}
+
+function formatStringWithDataType (value, datatype) {
+  const str = formatRDFString(value);
+  return datatype !== undefined ? str + "^^" + datatype.format() : str;
+}
+
+// ── Term.create ───────────────────────────────────────────────────────────────
+
+const KNOWN_XSD_DATATYPES = { boolean: 1, decimal: 1, double: 1, integer: 1 };
+
+Term.create = function create (value, options) {
+  if (options) return createTerm(Object.assign({}, options, { value }));
+  return createTerm(value);
+};
+
+function createTerm (value) {
+  const rawValue = value == null ? value : value.valueOf();
+  if (rawValue === null || rawValue === undefined) {
+    throw new TypeError("Cannot bind null or undefined value");
+  }
+  const type = typeof rawValue;
+  switch (type) {
+    case "string": return Literal.create(rawValue);
+    case "number": return Literal.createWithDataType(rawValue, { xsd: "double" });
+    case "boolean": return Literal.createWithDataType(rawValue, { xsd: "boolean" });
+    case "object": return createTermFromObject(rawValue);
+  }
+  throw new TypeError("Cannot bind " + type + " value: " + value);
+}
+
+function createTermFromObject (object) {
+  if (Object.keys(object).length === 1) return IRI.createFromObject(object);
+
+  const { value } = object;
+  if (value === undefined) {
+    throw new Error(
+      "Binding must contain a `value` property. " +
+      "To bind a URI, write { value: 'http://...', type: 'uri' }."
+    );
+  }
+
+  resolveDataTypeShortcuts(object);
+
+  if (object.type === "uri") return IRI.create(value);
+  if (object.lang !== undefined) return Literal.createWithLanguageTag(value, object.lang);
+  if (object["xml:lang"] !== undefined) return Literal.createWithLanguageTag(value, object["xml:lang"]);
+  if (object.datatype !== undefined) return Literal.createWithDataType(value, object.datatype);
+
+  throw new Error("Could not bind object: " + JSON.stringify(object));
+}
+
+function resolveDataTypeShortcuts (object) {
+  const TERM_TYPES = { bnode: 1, literal: 1, uri: 1 };
+  const { type } = object;
+  if (type === undefined || type in TERM_TYPES) return;
+  object.datatype = type in KNOWN_XSD_DATATYPES ? { xsd: type } : type;
+  object.type = "literal";
+}
+
+export default Term;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@lblod/mu-auth-sudo": "1.0.0-beta.4",
         "@rdfjs/namespace": "^1.1.0",
         "env-var": "^7.3.0",
+        "express-http-context": "^2.0.1",
         "jose": "^6.1.0",
         "ldes-client": "0.3.1",
         "n3": "^1.16.1",
@@ -1436,37 +1437,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.6",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
-      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/cls-hooked": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/@types/cls-hooked/-/cls-hooked-4.3.9.tgz",
-      "integrity": "sha512-CMtHMz6Q/dkfcHarq9nioXH8BDPP+v5xvd+N90lBQ2bdmu06UvnLDqxTKoOJzz4SzIwb/x9i4UXGAAcnUDuIvg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/cron": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/cron/-/cron-2.0.1.tgz",
@@ -1495,45 +1465,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/express": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
-      "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
-      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
-      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/http-link-header": {
       "version": "1.0.7",
@@ -1568,13 +1505,6 @@
         "@types/unist": "^2"
       }
     },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -1602,20 +1532,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/rdfjs__namespace": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-2.0.10.tgz",
@@ -1633,29 +1549,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/send": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
-      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.8",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
-      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
       }
     },
     "node_modules/@types/sparqljs": {
@@ -2267,19 +2160,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/async-hook-jl": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
-      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "stack-chain": "^1.3.7"
-      },
-      "engines": {
-        "node": "^4.7 || >=6.9 || >=7.3"
       }
     },
     "node_modules/async-retry": {
@@ -3063,31 +2943,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/cls-hooked": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
-      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "async-hook-jl": "^1.7.6",
-        "emitter-listener": "^1.0.1",
-        "semver": "^5.4.1"
-      },
-      "engines": {
-        "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
-      }
-    },
-    "node_modules/cls-hooked/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/color": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
@@ -3749,16 +3604,6 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/emitter-listener": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "shimmer": "^1.2.0"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -4482,18 +4327,12 @@
       }
     },
     "node_modules/express-http-context": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/express-http-context/-/express-http-context-1.2.5.tgz",
-      "integrity": "sha512-3wH4zvH7hkD/b0EJfAM7fafMzPqr7tKqWaVXJrEt6GH+U1a0WykIjoFY3pJbAke9Z78q6znz1Cpgm+Q5VsQsmw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/express-http-context/-/express-http-context-2.0.1.tgz",
+      "integrity": "sha512-2auIt7lQfhd/s+JAPwI87GOlPnbx9FdA5w45DH89tFQTQ4tzTFqqJAOKAMFwEUh8JRk3LglDUAL9tOe8el2+Sw==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/cls-hooked": "^4.2.1",
-        "@types/express": "^4.16.0",
-        "cls-hooked": "^4.2.2"
-      },
       "engines": {
-        "node": ">=8.0.0 <10.0.0 || >=10.4.0"
+        "node": ">=14.8.0"
       },
       "funding": {
         "url": "https://github.com/skonves/express-http-context?sponsor=1"
@@ -10265,13 +10104,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-      "license": "BSD-2-Clause",
-      "peer": true
-    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -10483,13 +10315,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/stack-chain": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.12.2",
       "license": "MIT",
       "dependencies": {
-        "@lblod/mu-auth-sudo": "1.0.0-beta.4",
         "@rdfjs/namespace": "^1.1.0",
         "env-var": "^7.3.0",
         "express-http-context": "^2.0.1",
@@ -995,20 +994,6 @@
       "license": "MIT",
       "dependencies": {
         "event-emitter-promisify": "^1.1.0"
-      }
-    },
-    "node_modules/@lblod/mu-auth-sudo": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@lblod/mu-auth-sudo/-/mu-auth-sudo-1.0.0-beta.4.tgz",
-      "integrity": "sha512-wb4bSfsaXZYquKhmKdMFoHT04536+a5q+t/wHZnFs9OfNdYyPPd6J5cJbonUPwHz+6iceXMor+2QQvRmpKcjPw==",
-      "license": "MIT",
-      "dependencies": {
-        "digest-fetch": "^1.3.0",
-        "env-var": "^7.0.1",
-        "node-fetch": "^2.6.7"
-      },
-      "peerDependencies": {
-        "express-http-context": "~1.2.4"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2201,11 +2186,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2702,15 +2682,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
@@ -3115,15 +3086,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/crypto-random-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
@@ -3475,16 +3437,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/digest-fetch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
-      "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
-      "license": "ISC",
-      "dependencies": {
-        "base-64": "^0.1.0",
-        "md5": "^2.3.0"
       }
     },
     "node_modules/dir-glob": {
@@ -5655,12 +5607,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "license": "MIT"
-    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -6991,17 +6937,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/mdast-util-from-markdown": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "typescript-eslint": "^8.48.0"
   },
   "dependencies": {
-    "@lblod/mu-auth-sudo": "1.0.0-beta.4",
     "@rdfjs/namespace": "^1.1.0",
     "env-var": "^7.3.0",
     "express-http-context": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@lblod/mu-auth-sudo": "1.0.0-beta.4",
     "@rdfjs/namespace": "^1.1.0",
     "env-var": "^7.3.0",
+    "express-http-context": "^2.0.1",
     "jose": "^6.1.0",
     "ldes-client": "0.3.1",
     "n3": "^1.16.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "allowImportingTsExtensions": true,
     "noEmit": true,
     "noImplicitAny": true,
-    "types": ["mu-types"]
+    "types": ["mu-types"],
+    "allowJs": true
   }
 }


### PR DESCRIPTION
### Overview
This PR adds support for sending normal (non-sudo) queries to the database if desired. Additionally, this also unlocks using mu-authorization scopes (see https://github.com/mu-semtech/sparql-parser#define-access-rights-for-specific-services).
The following (optional) environment variable is added in this PR:
- `USE_SUDO_QUERIES`: default value is `true`, as to not make this PR a breaking change.

A scope can be provided through the `DEFAULT_MU_AUTH_SCOPE` environment variable, provided by the mu-javascript-template image.

##### connected issues and PRs:
[DL-7358](https://binnenland.atlassian.net/browse/DL-7358?atlOrigin=eyJpIjoiMjE1MmExMDNiMDdhNGEwMmFmM2ViNjdhZGIwNWFiZGMiLCJwIjoiaiJ9)
https://github.com/mu-semtech/mu-javascript-template/pull/82

### Setup
Configure this service in your stack; ensure that `USE_SUDO_QUERIES` is set to `false`, and that `DEFAULT_MU_AUTH_SCOPE` is set to a scope of your choosing:
```yml
ldes-consumer:
   build: https://github.com/redpencilio/ldes-consumer-service.git#DL-7358-mu-auth-scope-support
   environment:
      USE_SUDO_QUERIES: false
      DEFAULT_MU_AUTH_SCOPE: <scope>
```

Configure the sparql-parser service in your stack with the above provided scope, ensure that the scope is able to access/write all the types/predicate provided by the ldes feed you are consuming. See https://github.com/mu-semtech/sparql-parser#define-access-rights-for-specific-services for more information.

### How to test/reproduce
- Start at least the following services in your stack
  * `virtuoso`/`triplestore`
  * `database`
  * `ldes-consumer`
- Ensure the ldes-consumer correctly consumes and ingests the configured ldes-feed.

- Additionally (if using): ensure that the `SPARQL_AUTH_USER` and `SPARQL_AUTH_PASSWORD` parameters still work as expected.

See example: https://github.com/lblod/app-ipdc-enrichment/pull/28

### Challenges/uncertainties
This PR inlines code from https://github.com/mu-semtech/mu-javascript-template/pull/82 (the new sparql client) which is not yet merged at the time of writing this PR. The sparql client of the current version of mu-javascript-template ([1.9.1](https://github.com/mu-semtech/mu-javascript-template/releases/tag/v1.9.1)) does not support providing custom headers.




### Checks PR readiness
- [x] npm lint
